### PR TITLE
Refactor RSS generation to use Jinja2 templates and improve S3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RSS Feed Generator
 
-A modern CLI tool for generating RSS feeds from websites and uploading them to MinIO.
+A modern CLI tool for generating RSS feeds from websites and uploading them to S3-compatible storage (AWS S3, MinIO, etc.).
 
 ## Installation
 
@@ -24,19 +24,64 @@ rss-generator generate immich
 # Generate all feeds
 rss-generator generate --all
 
+# Generate with custom bucket
+rss-generator generate --all --bucket my-feeds
+
+# Upload XSL stylesheet and get URL
+rss-generator upload-xsl
+
+# Generate with custom XSL stylesheet
+rss-generator generate immich --xsl-url https://example.com/feed.xsl
+
 # Check configuration
 rss-generator check
 ```
 
 ## Configuration
 
-Create a `.env` file:
+Create a `.env` file with your S3 credentials:
+
+### For AWS S3:
+
+```env
+S3_ACCESS_KEY=your-aws-access-key
+S3_SECRET_KEY=your-aws-secret-key
+S3_REGION=us-east-1
+S3_BUCKET=my-rss-feeds
+S3_PUBLIC_URL=https://my-bucket.s3.amazonaws.com
+```
+
+### For MinIO or S3-compatible storage:
+
+```env
+S3_ACCESS_KEY=your-access-key
+S3_SECRET_KEY=your-secret-key
+S3_ENDPOINT=https://minio.example.com
+S3_BUCKET=rss-feeds
+S3_PUBLIC_URL=https://minio.example.com  # Public URL for accessing files
+```
+
+### Legacy MinIO configuration (still supported):
 
 ```env
 MINIO_ACCESS_KEY=your-access-key
 MINIO_SECRET_KEY=your-secret-key
 MINIO_ENDPOINT=https://minio.example.com
 ```
+
+### Environment Variables Reference:
+
+| Variable | Description | Required | Default |
+|----------|-------------|----------|---------|
+| `S3_ACCESS_KEY` | S3 access key (or `MINIO_ACCESS_KEY`) | Yes | None |
+| `S3_SECRET_KEY` | S3 secret key (or `MINIO_SECRET_KEY`) | Yes | None |
+| `S3_ENDPOINT` | S3 endpoint URL (not needed for AWS S3) | No* | None |
+| `S3_BUCKET` | Bucket name for uploads | No | `rss-feeds` |
+| `S3_REGION` | AWS region | No | `us-east-1` |
+| `S3_PUBLIC_URL` | Public base URL for accessing feeds | Recommended | Falls back to `S3_ENDPOINT` |
+| `XSL_URL` | XSL stylesheet URL for browser-friendly RSS | No | Auto-generated from bucket |
+
+\* Required for MinIO and S3-compatible services. Not needed for AWS S3.
 
 ## Currently Supported Sites
 
@@ -46,6 +91,15 @@ MINIO_ENDPOINT=https://minio.example.com
 ## Want to Add a Site?
 
 [Create an issue](https://github.com/pedromcaraujo/rss-generator/issues/new) with the website URL and I'll add support for it!
+
+## Features
+
+- **Automated RSS Generation**: Scrape websites and generate valid RSS 2.0 feeds
+- **JavaScript Rendering**: Handle dynamic content with Playwright browser automation
+- **S3-Compatible Storage**: Upload feeds to AWS S3, MinIO, or any S3-compatible service
+- **Multiple Sites**: Support for multiple websites with easy configuration
+- **Beautiful CLI**: Rich terminal interface with progress indicators
+- **Optional XSL Styling**: Apply XSL stylesheets for browser-friendly RSS viewing
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "beautifulsoup4>=4.14.2",
     "boto3>=1.40.43",
     "feedgen>=1.0.0",
+    "jinja2>=3.1.0",
     "playwright>=1.55.0",
     "python-dotenv>=1.1.1",
     "requests>=2.32.5",
@@ -44,3 +45,4 @@ packages = ["rss_generator"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "rss_generator/feed.xsl" = "rss_generator/feed.xsl"
+"rss_generator/templates" = "rss_generator/templates"

--- a/rss_generator/cli.py
+++ b/rss_generator/cli.py
@@ -17,7 +17,7 @@ from .common import (
     generate_rss_feed,
     upload_to_minio,
 )
-from .parsers import get_parser
+from .parsers import get_parser, get_content_extractor, get_metadata_extractor
 from .sites import get_all_sites, get_site_config, list_sites
 
 app = typer.Typer(
@@ -31,7 +31,8 @@ console = Console()
 def process_site(
     site_id: str,
     upload: bool = True,
-    bucket_name: str = "rss-feeds"
+    bucket_name: Optional[str] = None,
+    xsl_url: Optional[str] = None
 ) -> bool:
     """
     Process a single site: fetch, parse, generate RSS, and optionally upload.
@@ -40,6 +41,7 @@ def process_site(
         site_id: Site identifier
         upload: Whether to upload to MinIO
         bucket_name: MinIO bucket name
+        xsl_url: Custom XSL stylesheet URL
 
     Returns:
         True if successful, False otherwise
@@ -48,6 +50,10 @@ def process_site(
     if not site_config:
         console.print(f"[red]Site '{site_id}' not found[/red]")
         return False
+
+    # Get bucket name from parameter or environment
+    if bucket_name is None:
+        bucket_name = os.getenv('S3_BUCKET', 'rss-feeds')
 
     output_file = site_config['output_file']
 
@@ -80,8 +86,50 @@ def process_site(
 
     console.print(f"[green]Found {len(articles)} articles[/green]")
 
+    # Limit articles if configured
+    max_articles = site_config.get('max_articles')
+    if max_articles and len(articles) > max_articles:
+        console.print(f"[cyan]Limiting to {max_articles} most recent articles[/cyan]")
+        articles = articles[:max_articles]
+
+    # Fetch full content and metadata for each article
+    content_extractor = get_content_extractor(site_config['parser'])
+    metadata_extractor = get_metadata_extractor(site_config['parser'])
+
+    if content_extractor or metadata_extractor:
+        console.print(f"[cyan]Fetching full content and metadata for articles...[/cyan]")
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=console,
+        ) as progress:
+            task = progress.add_task(f"Processing articles...", total=len(articles))
+
+            for article in articles:
+                if article.get('link'):
+                    article_html = fetch_page_with_playwright(
+                        article['link'],
+                        site_config.get('wait_time', 2000)
+                    )
+                    if article_html:
+                        # Extract content
+                        if content_extractor:
+                            content = content_extractor(article_html)
+                            if content:
+                                article['content'] = content
+
+                        # Extract metadata (author, image)
+                        if metadata_extractor:
+                            metadata = metadata_extractor(article_html)
+                            if metadata.get('author'):
+                                article['author'] = metadata['author']
+                            if metadata.get('image'):
+                                article['image'] = metadata['image']
+
+                progress.update(task, advance=1)
+
     # Generate RSS feed
-    if not generate_rss_feed(articles, output_file, site_config):
+    if not generate_rss_feed(articles, output_file, site_config, bucket_name, xsl_url):
         console.print(f"[red]Failed to generate RSS feed for {site_id}[/red]")
         return False
 
@@ -103,11 +151,18 @@ def process_site(
                 # Create marker file to avoid re-uploading XSL
                 Path(xsl_uploaded_marker).touch()
 
-        console.print(
-            f"[green]Uploaded to https://minio.example.com/{bucket_name}/{output_file}[/green]"
-        )
+        # Construct public URL from environment or endpoint
+        s3_public_url = os.getenv('S3_PUBLIC_URL') or os.getenv('S3_ENDPOINT') or os.getenv('MINIO_ENDPOINT')
+
+        if s3_public_url:
+            public_base = s3_public_url.replace('https://', '').replace('http://', '')
+            console.print(
+                f"[green]Uploaded to https://{public_base}/{bucket_name}/{output_file}[/green]"
+            )
+        else:
+            console.print(f"[green]Uploaded to bucket: {bucket_name}/{output_file}[/green]")
     elif upload:
-        console.print("[yellow]MinIO credentials not configured, skipping upload[/yellow]")
+        console.print("[yellow]S3 credentials not configured, skipping upload[/yellow]")
 
     return True
 
@@ -129,11 +184,17 @@ def generate(
         "--no-upload",
         help="Skip uploading to MinIO (local generation only)"
     ),
-    bucket: str = typer.Option(
-        "rss-feeds",
+    bucket: Optional[str] = typer.Option(
+        None,
         "--bucket",
         "-b",
-        help="MinIO bucket name"
+        help="S3 bucket name (defaults to S3_BUCKET env var or 'rss-feeds')"
+    ),
+    xsl_url: Optional[str] = typer.Option(
+        None,
+        "--xsl-url",
+        "-x",
+        help="Custom XSL stylesheet URL for browser-friendly RSS display"
     ),
 ):
     """Generate RSS feed(s) from configured websites."""
@@ -156,7 +217,7 @@ def generate(
             console.print(f"[bold]Processing: {site_id}[/bold]")
             console.print(f"[bold blue]{'='*60}[/bold blue]\n")
 
-            if process_site(site_id, upload=not no_upload, bucket_name=bucket):
+            if process_site(site_id, upload=not no_upload, bucket_name=bucket, xsl_url=xsl_url):
                 success_count += 1
             else:
                 failed_sites.append(site_id)
@@ -172,7 +233,7 @@ def generate(
             raise typer.Exit(1)
     else:
         # Process single site
-        if not process_site(site, upload=not no_upload, bucket_name=bucket):
+        if not process_site(site, upload=not no_upload, bucket_name=bucket, xsl_url=xsl_url):
             raise typer.Exit(1)
 
 
@@ -199,18 +260,67 @@ def list():
 
 
 @app.command()
+def upload_xsl(
+    bucket: Optional[str] = typer.Option(
+        None,
+        "--bucket",
+        "-b",
+        help="S3 bucket name (defaults to S3_BUCKET env var or 'rss-feeds')"
+    ),
+):
+    """Generate and upload XSL stylesheet, returning the public URL."""
+    if not check_minio_credentials():
+        console.print("[red]Error: S3 credentials not configured[/red]")
+        console.print("Set S3_ACCESS_KEY and S3_SECRET_KEY in .env file")
+        raise typer.Exit(1)
+
+    # Get bucket name from parameter or environment
+    if bucket is None:
+        bucket = os.getenv('S3_BUCKET', 'rss-feeds')
+
+    console.print(f"[cyan]Uploading XSL stylesheet to bucket '{bucket}'...[/cyan]")
+
+    # Upload the XSL stylesheet
+    if not upload_to_minio(str(XSL_FILE), bucket, "feed.xsl"):
+        console.print(f"[red]Failed to upload XSL stylesheet[/red]")
+        raise typer.Exit(1)
+
+    # Construct and display public URL
+    s3_public_url = os.getenv('S3_PUBLIC_URL') or os.getenv('S3_ENDPOINT') or os.getenv('MINIO_ENDPOINT')
+
+    if s3_public_url:
+        public_base = s3_public_url.replace('https://', '').replace('http://', '')
+        xsl_url = f"https://{public_base}/{bucket}/feed.xsl"
+        console.print(f"[green]✓[/green] XSL stylesheet uploaded successfully")
+        console.print(f"\n[bold]XSL URL:[/bold] {xsl_url}")
+        console.print(f"\nUse this URL with the --xsl-url flag:")
+        console.print(f"  rss-generator generate <site> --xsl-url {xsl_url}")
+    else:
+        console.print(f"[green]✓[/green] Uploaded to {bucket}/feed.xsl")
+        console.print("[yellow]Warning: S3_PUBLIC_URL not set, cannot display full URL[/yellow]")
+
+
+@app.command()
 def check():
     """Check configuration and environment."""
     console.print("[bold]RSS Generator Configuration Check[/bold]\n")
 
-    # Check MinIO credentials
+    # Check S3 credentials
     if check_minio_credentials():
-        console.print("[green]✓[/green] MinIO credentials configured")
-        endpoint = os.getenv('MINIO_ENDPOINT', 'https://minio.example.com')
+        console.print("[green]✓[/green] S3 credentials configured")
+        endpoint = os.getenv('S3_ENDPOINT') or os.getenv('MINIO_ENDPOINT') or 'Not set (AWS S3)'
+        bucket = os.getenv('S3_BUCKET', 'rss-feeds')
+        region = os.getenv('S3_REGION') or os.getenv('AWS_DEFAULT_REGION') or 'us-east-1 (default)'
+        public_url = os.getenv('S3_PUBLIC_URL') or 'Not set'
+
         console.print(f"  Endpoint: {endpoint}")
+        console.print(f"  Region: {region}")
+        console.print(f"  Bucket: {bucket}")
+        console.print(f"  Public URL: {public_url}")
     else:
-        console.print("[red]✗[/red] MinIO credentials NOT configured")
-        console.print("  Set MINIO_ACCESS_KEY and MINIO_SECRET_KEY in .env file")
+        console.print("[red]✗[/red] S3 credentials NOT configured")
+        console.print("  Set S3_ACCESS_KEY and S3_SECRET_KEY in .env file")
+        console.print("  Or use MINIO_ACCESS_KEY and MINIO_SECRET_KEY for backward compatibility")
 
     # List configured sites
     sites = list_sites()

--- a/rss_generator/sites.py
+++ b/rss_generator/sites.py
@@ -13,6 +13,7 @@ SITES = {
         'description': 'Latest posts from the Immich blog',
         'email': 'noreply@immich.app',
         'wait_time': 2000,
+        'max_articles': 10,  # Limit to most recent articles
     },
     'diariodominho': {
         'id': 'diariodominho',
@@ -24,6 +25,7 @@ SITES = {
         'description': 'Últimas notícias do Diário do Minho',
         'email': 'noreply@diariodominho.pt',
         'wait_time': 3000,
+        'max_articles': 10,  # Limit to most recent articles
     },
 }
 

--- a/rss_generator/templates/rss_feed.xml
+++ b/rss_generator/templates/rss_feed.xml
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+{% if xsl_url %}<?xml-stylesheet type="text/xsl" href="{{ xsl_url }}"?>{% endif %}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ channel.title }}</title>
+    <link>{{ channel.link }}</link>
+    <description>{{ channel.description }}</description>
+    <language>{{ channel.language }}</language>
+    <atom:link href="{{ channel.link }}" rel="self" type="application/rss+xml"/>
+    {% if channel.author %}
+    <managingEditor>{{ channel.author.email }} ({{ channel.author.name }})</managingEditor>
+    {% endif %}
+    <generator>RSS Generator</generator>
+    <lastBuildDate>{{ channel.last_build_date }}</lastBuildDate>
+
+    {% for item in items %}
+    <item>
+      <title>{{ item.title | escape }}</title>
+      <link>{{ item.link }}</link>
+      <guid isPermaLink="true">{{ item.link }}</guid>
+      <description>{{ item.description | escape }}</description>
+      {% if item.author %}
+      <author>{{ item.author.email }} ({{ item.author.name }})</author>
+      {% endif %}
+      {% if item.pub_date %}
+      <pubDate>{{ item.pub_date }}</pubDate>
+      {% endif %}
+      {% if item.category %}
+      <category>{{ item.category }}</category>
+      {% endif %}
+      {% if item.content %}
+      <content:encoded xmlns:content="http://purl.org/rss/1.0/modules/content/"><![CDATA[{{ item.content }}]]></content:encoded>
+      {% endif %}
+      {% if item.image %}
+      <enclosure url="{{ item.image }}" type="image/jpeg" length="0"/>
+      {% endif %}
+    </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/uv.lock
+++ b/uv.lock
@@ -168,6 +168,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jmespath"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -266,6 +278,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -374,6 +449,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "boto3" },
     { name = "feedgen" },
+    { name = "jinja2" },
     { name = "playwright" },
     { name = "python-dotenv" },
     { name = "requests" },
@@ -386,6 +462,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.14.2" },
     { name = "boto3", specifier = ">=1.40.43" },
     { name = "feedgen", specifier = ">=1.0.0" },
+    { name = "jinja2", specifier = ">=3.1.0" },
     { name = "playwright", specifier = ">=1.55.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
     { name = "requests", specifier = ">=2.32.5" },


### PR DESCRIPTION
## Summary
- Replace feedgen with Jinja2 templates for full control over RSS XML generation
- Fix pubDate generation (dates now appear correctly in RSS feeds)
- Add comprehensive S3 compatibility (AWS S3, MinIO, and S3-compatible services)
- Add XSL stylesheet URL configuration via environment variable or CLI parameter
- Extract full article content and metadata from individual article pages
- Improve HTML content cleaning

## Key Changes
- ✅ **Jinja2 Templates**: RSS feeds now generated from `rss_feed.xml` template
- ✅ **pubDate Fixed**: Using `format_datetime()` for RFC 2822 compliant dates
- ✅ **XSL_URL Support**: Set XSL stylesheet URL via environment variable
- ✅ **New Command**: `upload-xsl` to upload stylesheet and get public URL
- ✅ **S3 Generic**: Works with AWS S3, MinIO, and any S3-compatible service
- ✅ **Full Content**: Scrapes individual article pages for complete content
- ✅ **Metadata Extraction**: Author names and featured images now included
- ✅ **Better Documentation**: Comprehensive README with S3 configuration examples

## Testing
Tested with both Immich and Diário do Minho feeds - pubDate tags now appear correctly in generated RSS XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)